### PR TITLE
Remove webpack call from env.sh template

### DIFF
--- a/terraform/do/cabin/templates/env.tpl
+++ b/terraform/do/cabin/templates/env.tpl
@@ -19,5 +19,3 @@ export KEEN_WRITE_KEY=${KEEN_WRITE_KEY}
 export KEEN_READ_KEY=${KEEN_READ_KEY}
 export IMGIX_BASE_URL=https://react-example-app.imgix.net/uploads
 export API_URL=http://localhost:8000
-cd /home/cabin/stream-react-example/app
-webpack


### PR DESCRIPTION
The `env.sh` template creates `env.sh` on the prod server and runs as root. This fires webpack in the `app` folder but creates the `app/public/js/app.js` folder with `root` permissions. 

`env.sh` is sourced during deployment in `web.tpl`, causing the wrong permissions to be applied. Removing these lines from this template solves the issue.
