### PR TITLE
added extra origin url to cors to make move to /cabin possible

### DIFF
--- a/www/routes/index.js
+++ b/www/routes/index.js
@@ -21,7 +21,7 @@ router.get('/demo/', function(req, res, next) {
 /* POST mailchimp */
 router.post(
 	'/subscribe',
-	cors({ origin: 'https://getstream.io/blog' }),
+	cors({ origin: ['https://getstream.io/blog', 'https://getstream.io/cabin'] }),
 	function(req, res, next) {
 		var params = req.body;
 


### PR DESCRIPTION
To make the move to /cabin as easy as possible we can all logic on cabin.getstream.io. The only problem I ran in to is the email signup forms. 

I think modifying the cors is the easiest fix.